### PR TITLE
Levelup2

### DIFF
--- a/src/scenes/Collisions.ts
+++ b/src/scenes/Collisions.ts
@@ -10,6 +10,7 @@ import { Archer } from "../characters/Archer";
 import { Npc_wizard } from "../characters/Npc";
 import "../characters/Npc";
 import { Potion } from "../characters/Potion";
+import { update } from "firebase/database";
 // import { getDatabase, ref, onValue } from "firebase/database";
 // import { useRef } from "react";
 // import { setupFirebaseAuth } from "../utils/gameOnAuth";
@@ -50,7 +51,7 @@ export class CollisionHandler {
     this.potion = potion;
     this.playerId = playerId;
   }
-
+  
   // Method to handle collision between projectiles and walls
   handleProjectileWallCollision(
     obj1: Phaser.Types.Physics.Arcade.GameObjectWithBody | Phaser.Tilemaps.Tile,
@@ -128,7 +129,7 @@ export class CollisionHandler {
         console.log(`${character.constructor.name}'s exp: ${character.exp}`);
       }
     });
-  }
+}
 
   // Method to handle collision between player and enemy characters
   handlePlayerEnemyCollision(

--- a/src/scenes/Game.tsx
+++ b/src/scenes/Game.tsx
@@ -470,12 +470,26 @@ export default class Game extends Phaser.Scene {
       console.log("You have leveled up! Level:", player.level);
       console.log("HP:", player._health);
 
-      if (this.playerRef) { 
-        update(this.playerRef, {
-          exp: player.exp,
-          hp: player._health,
+      // Update the player's max health in the health bar
+    if (this.scene.isActive("player-ui")) {
+      this.scene.get("player-ui").events.emit("player-max-health-changed", player.maxHealth);
+    }
+
+    this.updatePlayerMaxHealth(player.maxHealth)
+
+    if (this.playerRef) { 
+      update(this.playerRef, {
+        exp: player.exp,
+        hp: player._health,
+        maxHealth: player.maxHealth,
+        level: player.level
         });
       }
+      if (this.playerLevel) {
+        this.playerLevel.text = "Level: " + player.level;
+      }
+      // Dispatch the event to update the health bar
+      sceneEvents.emit("player-max-health-changed", player.maxHealth);
     }
   }
   private levelUpArcher(player: Archer) {
@@ -490,12 +504,26 @@ export default class Game extends Phaser.Scene {
       console.log("You have leveled up! Level:", player.level);
       console.log("HP:", player._health);
 
-      if (this.playerRef) { 
-        update(this.playerRef, {
-          exp: player.exp,
-          hp: player._health,
+      // Update the player's max health in the health bar
+    if (this.scene.isActive("player-ui")) {
+      this.scene.get("player-ui").events.emit("player-max-health-changed", player.maxHealth);
+    }
+
+    this.updatePlayerMaxHealth(player.maxHealth)
+
+    if (this.playerRef) { 
+      update(this.playerRef, {
+        exp: player.exp,
+        hp: player._health,
+        maxHealth: player.maxHealth,
+        level: player.level
         });
       }
+      if (this.playerLevel) {
+        this.playerLevel.text = "Level: " + player.level;
+      }
+      // Dispatch the event to update the health bar
+      sceneEvents.emit("player-max-health-changed", player.maxHealth);
     }
   }
   private levelUpWizard(player: Wizard) {
@@ -510,12 +538,26 @@ export default class Game extends Phaser.Scene {
       console.log("You have leveled up! Level:", player.level);
       console.log("HP:", player._health);
 
-      if (this.playerRef) { 
-        update(this.playerRef, {
-          exp: player.exp,
-          hp: player._health,
+      // Update the player's max health in the health bar
+    if (this.scene.isActive("player-ui")) {
+      this.scene.get("player-ui").events.emit("player-max-health-changed", player.maxHealth);
+    }
+
+    this.updatePlayerMaxHealth(player.maxHealth)
+
+    if (this.playerRef) { 
+      update(this.playerRef, {
+        exp: player.exp,
+        hp: player._health,
+        maxHealth: player.maxHealth,
+        level: player.level
         });
       }
+      if (this.playerLevel) {
+        this.playerLevel.text = "Level: " + player.level;
+      }
+      // Dispatch the event to update the health bar
+      sceneEvents.emit("player-max-health-changed", player.maxHealth);
     }
   }
   private updatePlayerMaxHealth(maxHealth: number) {

--- a/src/scenes/Game.tsx
+++ b/src/scenes/Game.tsx
@@ -41,6 +41,8 @@ export default class Game extends Phaser.Scene {
   public otherPlayers!: Map<any, any>; // Map to store other players in the game
   public playerNames!: Map<any, any>; // Map to store player names
   public playerName?: Phaser.GameObjects.Text; // Text object to display the current player's name
+  public playerLevels!: Map<any, any>; // Map to store player levels
+  public playerLevel?: Phaser.GameObjects.Text; // Text object to display the current player's level
   public enemies!: Map<any, any>; // Map to store enemies in the game
   public enemyDB!: any;
   public dataToSend: any = {};
@@ -316,12 +318,22 @@ export default class Game extends Phaser.Scene {
         // Add text for player name
         this.playerName = this.add
           .text(0, 0, "You", {
-            fontSize: "10px",
+            fontSize: "14px",
             color: "#ffffff",
             stroke: "#000000",
-            strokeThickness: 2,
+            strokeThickness: 1,
           })
           .setOrigin(0.5, 1);
+
+        // Add text for player level
+        this.playerLevel = this.add
+        .text(0, 0, "Level: 1", {
+          fontSize: "12px",
+          color: "#FFD700",
+          stroke: "#000000",
+          strokeThickness: 1,
+        })
+        .setOrigin(0.5, 1)
       }
       this.Npc_wizard = this.physics.add.group({
         classType: Npc_wizard,
@@ -385,6 +397,11 @@ export default class Game extends Phaser.Scene {
       });
       this.potion.get(2062, 1023, "Potion");
       this.slimes.get(2000, 1000, "slime");
+      this.slimes.get(2000, 1000, "slime");
+      this.slimes.get(2000, 1000, "slime");
+      this.slimes.get(2000, 1000, "slime");
+      this.slimes.get(2000, 1000, "slime");
+      this.slimes.get(2000, 1000, "slime");
     }
 
     // Add a skeleton to the group
@@ -408,32 +425,52 @@ export default class Game extends Phaser.Scene {
   }
 
   private levelUpPlayer(player: Player) {
-    if (player.exp >= player.level * 10) {
-      player.exp -= player.level * 10; // Decrease the player's exp by current level * 10
-      player._health *= 1.25; // Increase the player's HP by 1.25 times
-      player._health = Math.round(player._health); // Round the player's HP to the nearest whole number
-      player.level++;
+    const expNeeded = player.level * 5 * Math.pow(1.5, player.level - 1); //Set the amout of exp need to level up to increase 1.5 times everytime the player levels up
+    if (player.exp >= expNeeded) {
+      player.exp -= expNeeded;
+      player._health *= 1.25; //increase the players current health by 1.25 times
+      player._health = Math.round(player._health); // Round the players health to the nearest whole number
+      player.maxHealth *=1.25; //increase the players max health by 1.25 times
+      player.maxHealth = Math.round(player.maxHealth) // Round the players max health to the nearest whole number
+      player.level++; // level the player up
       console.log("You have leveled up! Level:", player.level);
       console.log("HP:", player._health);
-      // Update the player's exp and HP in the database
-      if (this.playerRef) {
-        update(this.playerRef, {
-          exp: player.exp,
-          hp: player._health,
+
+      // Update the player's max health in the health bar
+    if (this.scene.isActive("player-ui")) {
+      this.scene.get("player-ui").events.emit("player-max-health-changed", player.maxHealth);
+    }
+
+    this.updatePlayerMaxHealth(player.maxHealth)
+
+    if (this.playerRef) { 
+      update(this.playerRef, {
+        exp: player.exp,
+        hp: player._health,
+        maxHealth: player.maxHealth,
+        level: player.level
         });
       }
+      if (this.playerLevel) {
+        this.playerLevel.text = "Level: " + player.level;
+      }
+      // Dispatch the event to update the health bar
+      sceneEvents.emit("player-max-health-changed", player.maxHealth);
     }
   }
   private levelUpBarb(player: Barb) {
-    if (player.exp >= player.level * 10) {
-      player.exp -= player.level * 10; // Decrease the player's exp by current level * 10
-      player._health *= 1.25; // Increase the player's HP by 1.25 times
-      player._health = Math.round(player._health); // Round the player's HP to the nearest whole number
-      player.level++;
+    const expNeeded = player.level * 5 * Math.pow(1.5, player.level - 1); //Set the amout of exp need to level up to increase 1.5 times everytime the player levels up
+    if (player.exp >= expNeeded) {
+      player.exp -= expNeeded;
+      player._health *= 1.25; //increase the players current health by 1.25 times
+      player._health = Math.round(player._health); // Round the players health to the nearest whole number
+      player.maxHealth *=1.25; //increase the players max health by 1.25 times
+      player.maxHealth = Math.round(player.maxHealth) // Round the players max health to the nearest whole number
+      player.level++; // level the player up
       console.log("You have leveled up! Level:", player.level);
       console.log("HP:", player._health);
-      // Update the player's exp and HP in the database
-      if (this.playerRef) {
+
+      if (this.playerRef) { 
         update(this.playerRef, {
           exp: player.exp,
           hp: player._health,
@@ -442,15 +479,18 @@ export default class Game extends Phaser.Scene {
     }
   }
   private levelUpArcher(player: Archer) {
-    if (player.exp >= player.level * 10) {
-      player.exp -= player.level * 10; // Decrease the player's exp by current level * 10
-      player._health *= 1.25; // Increase the player's HP by 1.25 times
-      player._health = Math.round(player._health); // Round the player's HP to the nearest whole number
-      player.level++;
+    const expNeeded = player.level * 5 * Math.pow(1.5, player.level - 1); //Set the amout of exp need to level up to increase 1.5 times everytime the player levels up
+    if (player.exp >= expNeeded) {
+      player.exp -= expNeeded;
+      player._health *= 1.25; //increase the players current health by 1.25 times
+      player._health = Math.round(player._health); // Round the players health to the nearest whole number
+      player.maxHealth *=1.25; //increase the players max health by 1.25 times
+      player.maxHealth = Math.round(player.maxHealth) // Round the players max health to the nearest whole number
+      player.level++; // level the player up
       console.log("You have leveled up! Level:", player.level);
       console.log("HP:", player._health);
-      // Update the player's exp and HP in the database
-      if (this.playerRef) {
+
+      if (this.playerRef) { 
         update(this.playerRef, {
           exp: player.exp,
           hp: player._health,
@@ -459,15 +499,18 @@ export default class Game extends Phaser.Scene {
     }
   }
   private levelUpWizard(player: Wizard) {
-    if (player.exp >= player.level * 10) {
-      player.exp -= player.level * 10; // Decrease the player's exp by current level * 10
-      player._health *= 1.25; // Increase the player's HP by 1.25 times
-      player._health = Math.round(player._health); // Round the player's HP to the nearest whole number
-      player.level++;
+    const expNeeded = player.level * 5 * Math.pow(1.5, player.level - 1); //Set the amout of exp need to level up to increase 1.5 times everytime the player levels up
+    if (player.exp >= expNeeded) {
+      player.exp -= expNeeded;
+      player._health *= 1.25; //increase the players current health by 1.25 times
+      player._health = Math.round(player._health); // Round the players health to the nearest whole number
+      player.maxHealth *=1.25; //increase the players max health by 1.25 times
+      player.maxHealth = Math.round(player.maxHealth) // Round the players max health to the nearest whole number
+      player.level++; // level the player up
       console.log("You have leveled up! Level:", player.level);
       console.log("HP:", player._health);
-      // Update the player's exp and HP in the database
-      if (this.playerRef) {
+
+      if (this.playerRef) { 
         update(this.playerRef, {
           exp: player.exp,
           hp: player._health,
@@ -475,10 +518,19 @@ export default class Game extends Phaser.Scene {
       }
     }
   }
+  private updatePlayerMaxHealth(maxHealth: number) {
+    // Update the player's max health value in the database
+    if (this.playerRef) {
+      update(this.playerRef, {
+        maxHealth: maxHealth,
+      });
+    }
+  }
 
   update() {
     this.updateIterations++;
     let character;
+
 
     if (this.man) {
       this.man.update();
@@ -511,7 +563,10 @@ export default class Game extends Phaser.Scene {
       // Update the player's name position horizontally
       this.playerName.x = character.x;
       // Position of the name above the player
-      this.playerName.y = character.y - 10;
+      this.playerName.y = character.y - 20;
+
+      this.playerLevel.x = this.playerName.x
+      this.playerLevel.y = character.y - 10
 
       //Handle Collision Between Player and Potions
       this.physics.overlap(

--- a/src/scenes/PlayerUI.tsx
+++ b/src/scenes/PlayerUI.tsx
@@ -25,6 +25,11 @@ export default class PlayerUI extends Phaser.Scene {
       this.handlePlayerHealthChanged,
       this
     );
+    sceneEvents.on(
+      "player-max-health-changed",
+      this.handlePlayerMaxHealthChanged,
+      this
+    );
 
     this.bar = new HealthBar(this, x, y, fullWidth)
       .withLeftCap(this.add.image(0, 0, "healthBar-left-cap"))
@@ -44,4 +49,9 @@ export default class PlayerUI extends Phaser.Scene {
     //Requires two arguments, health and duration(ms)
     this.bar.animateToFill(health / 10, 1000);
   }
+  private handlePlayerMaxHealthChanged(maxHealth: number) {
+    console.log("Player's max health changed:", maxHealth);
+    // Update the width of the health bar to match the new max health value
+    this.bar.layout();
+  }  
 }


### PR DESCRIPTION
-Fixed All bugs/Issues
-Visual indicator when you level up
-Exp needed to level up is now 5 and is multiplied by 1.5 every time you level up
-Both max health and current health are increased by 1.25 when you level up
-Max health is now registered in the database and updated when you level up